### PR TITLE
Avoid potential thread safety issues in LogCapturer

### DIFF
--- a/src/main/org/apache/ant/antunit/LogCapturer.java
+++ b/src/main/org/apache/ant/antunit/LogCapturer.java
@@ -23,6 +23,7 @@ package org.apache.ant.antunit;
 import java.util.Iterator;
 import java.util.List;
 import java.util.LinkedList;
+import java.util.Collections;
 
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.BuildListener;
@@ -40,7 +41,7 @@ import org.apache.tools.ant.util.StringUtils;
 public class LogCapturer implements BuildListener {
     public static final String REFERENCE_ID = "ant.antunit.log";
 
-    private List/*<BuildEvent>*/ events = new LinkedList();
+    private List/*<BuildEvent>*/ events = Collections.synchronizedList(new LinkedList());
     private Project p;
 
     public LogCapturer(Project p) {


### PR DESCRIPTION
This commit is prompted by the exception I saw in one of the Ant Jenkins jobs which failed with:

```
/home/jenkins/jenkins-slave/workspace/Ant-Build-Matrix-master-Linux/OS/xenial/jdk/JDK 1.8 (latest)/src/tests/antunit/taskdefs/exec/exec-test.xml:528: java.lang.NullPointerException
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:109)
	at org.apache.tools.ant.TaskAdapter.execute(TaskAdapter.java:155)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
	at org.apache.tools.ant.Task.perform(Task.java:350)
	at java.util.Vector.forEach(Vector.java:1275)
	at org.apache.tools.ant.taskdefs.Sequential.execute(Sequential.java:67)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
	at org.apache.tools.ant.Task.perform(Task.java:350)
	at org.apache.tools.ant.taskdefs.MacroInstance.execute(MacroInstance.java:393)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
	at org.apache.tools.ant.Task.perform(Task.java:350)
	at org.apache.tools.ant.Target.execute(Target.java:449)
	at org.apache.tools.ant.Target.performTasks(Target.java:470)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1392)
	at org.apache.tools.ant.helper.SingleCheckExecutor.executeTargets(SingleCheckExecutor.java:36)
	at org.apache.tools.ant.Project.executeTargets(Project.java:1253)
	at org.apache.ant.antunit.AntUnitScriptRunner.runTarget(AntUnitScriptRunner.java:224)
	at org.apache.ant.antunit.AntUnitScriptRunner.runSuite(AntUnitScriptRunner.java:303)
	at org.apache.ant.antunit.AntUnit.doFile(AntUnit.java:268)
	at org.apache.ant.antunit.AntUnit.doResourceCollection(AntUnit.java:247)
	at org.apache.ant.antunit.AntUnit.execute(AntUnit.java:218)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
	at org.apache.tools.ant.Task.perform(Task.java:350)
	at org.apache.tools.ant.Target.execute(Target.java:449)
	at org.apache.tools.ant.Target.performTasks(Target.java:470)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1392)
	at org.apache.tools.ant.Project.executeTarget(Project.java:1363)
	at org.apache.tools.ant.helper.DefaultExecutor.executeTargets(DefaultExecutor.java:41)
	at org.apache.tools.ant.Project.executeTargets(Project.java:1253)
	at org.apache.tools.ant.Main.runBuild(Main.java:845)
	at org.apache.tools.ant.Main.startAnt(Main.java:228)
	at org.apache.tools.ant.launch.Launcher.run(Launcher.java:284)
	at org.apache.tools.ant.launch.Launcher.main(Launcher.java:101)
Caused by: java.lang.NullPointerException
	at java.util.LinkedList$ListItr.next(LinkedList.java:893)
	at org.apache.ant.antunit.LogCapturer.getLog(LogCapturer.java:178)
	at org.apache.ant.antunit.LogCapturer.getInfoLog(LogCapturer.java:114)
	at org.apache.ant.antunit.LogContains.eval(LogContains.java:81)
	at org.apache.ant.antunit.AssertTask.execute(AssertTask.java:71)
	at sun.reflect.GeneratedMethodAccessor42.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
	... 48 more
```
That specific race condition itself is handled by a previous commit in this project here https://github.com/apache/ant-antlibs-antunit/commit/7d62d95ab3a3df61937d2f66ad07fa75ed61aa75. But the `events` List is still susceptible to race conditions, hence this new commit.

